### PR TITLE
Fix path to links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,9 +21,9 @@ latex:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
-  path_to_book: docs  # Optional path to your book, relative to the repository root
-  branch: master  # Which branch of the repository should be used when creating links (optional)
+  url: https://github.com/tensor4all/T4AJuliaTutorials  # Online location of your book
+  path_to_book: "."  # Optional path to your book, relative to the repository root
+  branch: main  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository

--- a/interfacingwithitensors.jl
+++ b/interfacingwithitensors.jl
@@ -15,7 +15,7 @@
 # ---
 
 # %% [markdown]
-# Click [here](https://gitlab.com/api/v4/projects/56283350/jobs/artifacts/main/raw/notebooks/interfacingwithitensors.ipynb?job=pages) to download the notebook locally.
+# Click [here](https://tensor4all.org/T4AJuliaTutorials/_sources/ipynbs/interfacingwithitensors.ipynb) to download the notebook locally.
 #
 
 # %% [markdown]

--- a/pythonplot.jl
+++ b/pythonplot.jl
@@ -15,6 +15,9 @@
 # ---
 
 # %% [markdown]
+# Click [here](https://tensor4all.org/T4AJuliaTutorials/_sources/ipynbs/pythonplot.ipynb) to download the notebook locally.
+
+# %% [markdown]
 # # PythonPlot
 #
 # [JuliaPy/PythonPlot.jl](https://github.com/JuliaPy/PythonPlot.jl) provides a Julia interface to the [Matplotlib](https://matplotlib.org/) plotting library from Python, and specifically to the matplotlib.pyplot module. This may be helpful for those who are new to Julia and come from Python.

--- a/quantics1d.jl
+++ b/quantics1d.jl
@@ -16,7 +16,7 @@
 # ---
 
 # %% [markdown]
-# Click [here](https://gitlab.com/api/v4/projects/56283350/jobs/artifacts/main/raw/notebooks/quantics1d.ipynb?job=pages) to download the notebook locally.
+# Click [here](https://tensor4all.org/T4AJuliaTutorials/_sources/ipynbs/quantics1d.ipynb) to download the notebook locally.
 #
 
 # %% [markdown]

--- a/quantics1d_advanced.jl
+++ b/quantics1d_advanced.jl
@@ -15,7 +15,7 @@
 # ---
 
 # %% [markdown]
-# Click [here](https://gitlab.com/api/v4/projects/56283350/jobs/artifacts/main/raw/notebooks/quantics1d_advanced.ipynb?job=pages) to download the notebook locally.
+# Click [here](https://tensor4all.org/T4AJuliaTutorials/_sources/ipynbs/quantics1d_advanced.ipynb) to download the notebook locally.
 #
 
 # %% [markdown]
@@ -38,7 +38,7 @@ import TensorCrossInterpolation as TCI
 #
 # ### Performance tips
 #
-# Let's recall again the function $f(x)$ from the [previous page](quantics1d.md).
+# Let's recall again the function $f(x)$ from the [previous page](quantics1d.jl).
 #
 # $$
 # f(x) = \cos\left(\frac{x}{B}\right) \cos\left(\frac{x}{4\sqrt{5}B}\right) e^{-x^2} + 2e^{-x},
@@ -46,7 +46,7 @@ import TensorCrossInterpolation as TCI
 #
 # where $B = 2^{-30}$.
 #
-# In the [previous page](quantics1d.md), we implemented $f(x)$ as
+# In the [previous page](quantics1d.jl), we implemented $f(x)$ as
 #
 
 # %% [markdown]

--- a/quantics1d_advanced.jl
+++ b/quantics1d_advanced.jl
@@ -38,7 +38,7 @@ import TensorCrossInterpolation as TCI
 #
 # ### Performance tips
 #
-# Let's recall again the function $f(x)$ from the [previous page](quantics1d.jl).
+# Let's recall again the function $f(x)$ from the [previous page](./quantics1d.ipynb).
 #
 # $$
 # f(x) = \cos\left(\frac{x}{B}\right) \cos\left(\frac{x}{4\sqrt{5}B}\right) e^{-x^2} + 2e^{-x},
@@ -46,7 +46,7 @@ import TensorCrossInterpolation as TCI
 #
 # where $B = 2^{-30}$.
 #
-# In the [previous page](quantics1d.jl), we implemented $f(x)$ as
+# In the [previous page](./quantics1d.ipynb), we implemented $f(x)$ as
 #
 
 # %% [markdown]

--- a/quantics2d.jl
+++ b/quantics2d.jl
@@ -17,7 +17,7 @@
 # ---
 
 # %% [markdown]
-# Click [here](https://gitlab.com/api/v4/projects/56283350/jobs/artifacts/main/raw/notebooks/quantics2d.ipynb?job=pages) to download the notebook locally.
+# Click [here](https://tensor4all.org/T4AJuliaTutorials/_sources/ipynbs/quantics2d.ipynb) to download the notebook locally.
 #
 
 # %% [markdown]


### PR DESCRIPTION
Since our project was developed earlier, there are many links related to GitLab. This PR updates the path to the link that is compatible with our current GitHub repository.