### PR TITLE
Lock matplotlib version to 3.8 in CondaPkg.toml

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -3,3 +3,4 @@ channels = ["conda-forge"]
 [deps]
 jupytext = "==1.16.1"
 jupyter-book = ""
+matplotlib = "3.8"


### PR DESCRIPTION
This PR fixes a web page rendering bug caused by the matplotlib version.

<img width="857" alt="image" src="https://github.com/tensor4all/T4AJuliaTutorials/assets/16760547/465cbc57-7911-43c9-83d8-fa9d66ba2c24">

On my machine, the problem is solved. See the attached image below:

<img width="887" alt="image" src="https://github.com/tensor4all/T4AJuliaTutorials/assets/16760547/bb0e47b2-d352-4982-a61e-b76ffd4327f7">
