### PR TITLE
Add GitHub workflow for uploading notebooks

### DIFF
--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -1,4 +1,4 @@
-name: UploadNotebooks
+name: UploadMaterials
 on:
   push:
     branches:

--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -1,0 +1,52 @@
+name: UploadNotebooks
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  deploy:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+      - name: Add Julia Registries
+        run: |
+          julia -e '
+          using Pkg
+          Pkg.Registry.add(
+            RegistrySpec(url = "https://github.com/tensor4all/T4ARegistry.git")
+          )'
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: ./_build
+          key: ${{ runner.os }}-deploy-${{ hashFiles('_config.yml', '_toc.yml') }}
+      - name: Build Jupyter Book
+        run: |
+          julia --project -e 'using Pkg; Pkg.build("IJulia")'
+          make
+      - name: Copy project files to ipynbs
+        run: |
+          cp Project.toml Manifest.toml _build/jupyter_execute/ipynbs/
+      - name: upload Notebooks to release page
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          tag: ipynbs/latest
+          artifacts: _build/jupyter_execute/ipynbs/
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -44,7 +44,6 @@ jobs:
           cp Project.toml Manifest.toml _build/jupyter_execute/ipynbs/
       - name: zip ipynbs
         run: |
-          cd _build/jupyter_execute/ipynbs/
           zip -r ipynbs.zip _build/jupyter_execute/ipynbs/
       - name: upload Notebooks to ipynbs/preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -44,7 +44,9 @@ jobs:
           cp Project.toml Manifest.toml _build/jupyter_execute/ipynbs/
       - name: zip ipynbs
         run: |
-          zip -r ipynbs.zip _build/jupyter_execute/ipynbs/
+          cd _build/jupyter_execute/ipynbs/
+          zip -r ipynbs.zip .
+          mv ipynbs.zip ../../../
       - name: upload Notebooks to ipynbs/preview
         if: github.event_name == 'pull_request'
         uses: ncipollo/release-action@v1

--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     tags: ['*']
+  pull_request:
   workflow_dispatch:
 concurrency:
   # Skip intermediate builds: always.
@@ -42,7 +43,18 @@ jobs:
       - name: Copy project files to ipynbs
         run: |
           cp Project.toml Manifest.toml _build/jupyter_execute/ipynbs/
-      - name: upload Notebooks to release page
+      - name: upload Notebooks to ipynbs/preview
+        if: github.event_name == 'pull_request'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          tag: ipynbs/latest
+          artifacts: _build/jupyter_execute/ipynbs/
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: upload Notebooks to ipynbs/latest
+        if: github.ref == 'refs/heads/main'
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/UploadMaterials.yml
+++ b/.github/workflows/UploadMaterials.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  deploy:
+  upload:
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -42,14 +42,18 @@ jobs:
       - name: Copy project files to ipynbs
         run: |
           cp Project.toml Manifest.toml _build/jupyter_execute/ipynbs/
+      - name: zip ipynbs
+        run: |
+          cd _build/jupyter_execute/ipynbs/
+          zip -r ipynbs.zip _build/jupyter_execute/ipynbs/
       - name: upload Notebooks to ipynbs/preview
         if: github.event_name == 'pull_request'
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
-          tag: ipynbs/latest
-          artifacts: _build/jupyter_execute/ipynbs/
+          tag: ipynbs/preview
+          artifacts: ipynbs.zip
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: upload Notebooks to ipynbs/latest
@@ -59,5 +63,5 @@ jobs:
           allowUpdates: true
           omitBodyDuringUpdate: true
           tag: ipynbs/latest
-          artifacts: _build/jupyter_execute/ipynbs/
+          artifacts: ipynbs.zip
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds new workflow file `.github/workflows/UploadMaterials.yml` that uploads pre-built ipynb notebooks and `Project.toml` and `Manifest.toml` to release page `pynbs/preview` or `pynbs/latest`. This should be useful those who teaches topics on packages hosted in T4A group.